### PR TITLE
Fixed the spawn point errors and camera changing, refactored

### DIFF
--- a/source/Flag/Flag.gd
+++ b/source/Flag/Flag.gd
@@ -10,7 +10,7 @@ func _process(delta: float) -> void:
 	pass
 
 func _on_body_entered(body: Node) -> void:
-	get_parent().change_to_level(next_level, body)
+	get_parent().call_deferred("change_to_level", next_level, body)
 
 func _get_configuration_warning() -> String:
 	return "next_level needs a Scene/Level to function!" if not next_level else ""

--- a/source/Levels/Level.gd
+++ b/source/Levels/Level.gd
@@ -35,7 +35,7 @@ func _set_player(new_player):
 
 func _on_Corpse_Spawner_corpse_spawned(corpse):
 	corpses_parent.add_child(corpse)
-	
+
 func _on_StateMachine_entered_state(state):
 	if state == "Spawn":
 		player.global_position = get_node(spawn_point).global_position
@@ -54,6 +54,9 @@ func change_to_level(next_level, player):
 	main.add_child(next_level_instance)
 	
 	player.global_position = next_level_instance.get_node(next_level_instance.spawn_point).global_position
+	
+	$Camera_Rig.current = false
+	next_level_instance.get_node("Camera_Rig").current = true
 
 # Used to remind the Developer that a SpawnPoint is needed for spawn_point export.
 func _get_configuration_warning() -> String:

--- a/source/Levels/Level.gd
+++ b/source/Levels/Level.gd
@@ -4,21 +4,13 @@ extends Node2D
 
 # For adding a Spawn Point to the level
 export (NodePath) var spawn_point = null # Remember to turn off visibility on SpawnPoint.
-var target_spawn_point
 
 onready var corpses_parent := $Corpses
 onready var player := $Player setget _set_player
 
 func _ready() -> void:
-	#target_spawn_point = get_node(spawn_point)
-	#print("Spawn Point position: " + str(target_spawn_point.global_position))
-	
 	# See further below for needed fix for respawn on death issue.
-	set_first_spawn_position()
 	_set_player(player)
-
-func _process(delta: float) -> void:
-	update_spawn_point_position()
 
 func _set_player(new_player):
 	if player and player.get_node("Corpse_Spawner").is_connected("created_corpse", self, "_on_Corpse_Spawner_corpse_spawned"):
@@ -48,20 +40,9 @@ func change_to_level(next_level, player):
 	var main = get_parent()
 	main.call_deferred("remove_child", current_level)
 	main.call_deferred("add_child", next_level_instance)
+	
+	player.global_position = next_level_instance.get_node(next_level_instance.spawn_point).global_position
 
 # Used to remind the Developer that a SpawnPoint is needed for spawn_point export.
 func _get_configuration_warning() -> String:
 	return "spawn_point export needs a SpawnPoint to function!" if not spawn_point else ""
-
-# Sets the Player's Spawn Point position for the first time.
-func set_first_spawn_position() -> void:
-	target_spawn_point = get_node(spawn_point)
-	print("Spawn Point position: " + str(target_spawn_point.global_position))
-	player.global_position = target_spawn_point.global_position
-
-# "Updates" the Player's Spawn Point position when the Player dies.
-func update_spawn_point_position() -> void:
-	#target_spawn_point = get_node(spawn_point) # This one is maybe unneeded?
-	# When the player spawns, set it to the "SpawnPoint"
-	if player.state_machine.state.name == "Spawn":
-		player.global_position = target_spawn_point.global_position

--- a/source/Levels/Level.gd
+++ b/source/Levels/Level.gd
@@ -30,16 +30,16 @@ func _on_Corpse_Spawner_corpse_spawned(corpse):
 
 func change_to_level(next_level, player):
 	var current_level = self
-	current_level.call_deferred("remove_child", player)
+	current_level.remove_child(player)
 	
 	var next_level_instance = next_level.instance()
 	current_level.player = null
 	current_level.spawn_point = null
-	next_level_instance.call_deferred("add_child",player)
+	next_level_instance.add_child(player)
 
 	var main = get_parent()
-	main.call_deferred("remove_child", current_level)
-	main.call_deferred("add_child", next_level_instance)
+	main.remove_child(current_level)
+	main.add_child(next_level_instance)
 	
 	player.global_position = next_level_instance.get_node(next_level_instance.spawn_point).global_position
 

--- a/source/Levels/Level.gd
+++ b/source/Levels/Level.gd
@@ -17,16 +17,28 @@ func _set_player(new_player):
 		player.get_node("Corpse_Spawner").disconnect(
 			"created_corpse", self, "_on_Corpse_Spawner_corpse_spawned"
 		)
+		
+		player.get_node("StateMachine").disconnect(
+			"entered_state", self, "_on_StateMachine_entered_state"
+		)
 	
 	if new_player != null and new_player.has_node("Corpse_Spawner"):
 		new_player.get_node("Corpse_Spawner").connect(
 			"created_corpse", self, "_on_Corpse_Spawner_corpse_spawned"
+		)
+		
+		new_player.get_node("StateMachine").connect(
+			"entered_state", self, "_on_StateMachine_entered_state"
 		)
 	
 	player = new_player
 
 func _on_Corpse_Spawner_corpse_spawned(corpse):
 	corpses_parent.add_child(corpse)
+	
+func _on_StateMachine_entered_state(state):
+	if state == "Spawn":
+		player.global_position = get_node(spawn_point).global_position
 
 func change_to_level(next_level, player):
 	var current_level = self

--- a/source/Main/StateMachine/StateMachine.gd
+++ b/source/Main/StateMachine/StateMachine.gd
@@ -1,7 +1,7 @@
 extends Node
 
 class_name StateMachine, "res://assets/Icons/state_machine.svg"
-
+signal entered_state(state)
 
 export var initial_state: = NodePath()
 
@@ -31,6 +31,7 @@ func transition_to(target_state_path: String, message: Dictionary = {}) -> void:
 	var target_state: = get_node(target_state_path)
 	state.exit()
 	self.state = target_state
+	emit_signal("entered_state", target_state.name)
 	state.enter(message)
 
 func set_state(value: State) -> void:

--- a/source/Player/States/Spawn.gd
+++ b/source/Player/States/Spawn.gd
@@ -1,17 +1,13 @@
 extends State
 
-var _start_position: = Vector2.ZERO
-
 func _ready() -> void:
 	yield(owner, "ready")
-	_start_position = owner.position
 
 func _on_PlayerSkin_animation_finished(anim_name: String) -> void:
 	_state_machine.transition_to("Move/Air")
 
 func enter(message: Dictionary = {}) -> void:
 	owner.is_active = false
-	owner.position = _start_position
 	#if owner.camera_rig:
 	#	owner.camera_rig.is_active = false # This is for a "Camera rig" that we might want to reset.
 	owner.skin.play("Spawning")


### PR DESCRIPTION
I moved setting the player position to the change_to_level function, since that's the moment that you really want to do it at. You overcomplicated the spawn point situation by using two variables in Level.gd and creating functions for updating them, so I removed those to simplify things. I also refactored to using the call_deferred workaround once in Flag.gd instead of calling it several times in Level.gd.